### PR TITLE
Remove third party library, then use native http to test

### DIFF
--- a/compress_test.go
+++ b/compress_test.go
@@ -78,10 +78,11 @@ func TestGearResponseCompress(t *testing.T) {
 		t.Run("gzip compress", func(t *testing.T) {
 			assert := assert.New(t)
 
-			req := NewRequst()
-			req.Headers["Accept-Encoding"] = "gzip, deflate"
+			req, _ := NewRequst("GET", host+"/full")
 
-			res, err := req.Get(host + "/full")
+			req.Header.Set("Accept-Encoding", "gzip, deflate")
+
+			res, err := DefaultClientDo(req)
 			assert.Nil(err)
 			assert.True(res.OK())
 			content := PickRes(ioutil.ReadAll(res.Body)).([]byte)
@@ -99,10 +100,9 @@ func TestGearResponseCompress(t *testing.T) {
 		t.Run("deflate compress", func(t *testing.T) {
 			assert := assert.New(t)
 
-			req := NewRequst()
-			req.Headers["Accept-Encoding"] = "deflate,gzip"
-
-			res, err := req.Get(host + "/full")
+			req, _ := NewRequst("GET", host+"/full")
+			req.Header.Set("Accept-Encoding", "deflate,gzip")
+			res, err := DefaultClientDo(req)
 			assert.Nil(err)
 			assert.True(res.OK())
 			content := PickRes(ioutil.ReadAll(res.Body)).([]byte)
@@ -120,10 +120,10 @@ func TestGearResponseCompress(t *testing.T) {
 		t.Run("when no Accept-Encoding", func(t *testing.T) {
 			assert := assert.New(t)
 
-			req := NewRequst()
-			req.Headers["Accept-Encoding"] = ""
+			req, _ := NewRequst("GET", host+"/full")
+			req.Header.Set("Accept-Encoding", "")
 
-			res, err := req.Get(host + "/full")
+			res, err := DefaultClientDo(req)
 			assert.Nil(err)
 			assert.True(res.OK())
 			content := PickRes(res.Content()).([]byte)
@@ -137,10 +137,9 @@ func TestGearResponseCompress(t *testing.T) {
 		t.Run("compress threshold", func(t *testing.T) {
 			assert := assert.New(t)
 
-			req := NewRequst()
-			req.Headers["Accept-Encoding"] = "gzip, deflate"
-
-			res, err := req.Get(host + "/short")
+			req, _ := NewRequst("GET", host+"/short")
+			req.Header.Set("Accept-Encoding", "gzip, deflate")
+			res, err := DefaultClientDo(req)
 			assert.Nil(err)
 			assert.True(res.OK())
 			content := PickRes(res.Content()).([]byte)
@@ -170,9 +169,9 @@ func TestGearResponseCompress(t *testing.T) {
 
 			host := "http://" + srv.Addr().String()
 
-			req := NewRequst()
+			req, _ := NewRequst("GET", host+"/full")
 
-			res, err := req.Get(host + "/full")
+			res, err := DefaultClientDo(req)
 			assert.Nil(err)
 			assert.True(res.OK())
 			content := PickRes(res.Content()).([]byte)
@@ -209,17 +208,15 @@ func TestGearResponseCompress(t *testing.T) {
 
 			host := "http://" + srv.Addr().String()
 
-			req := NewRequst()
-
-			res, _ := req.Get(host + "/204")
+			res, _ := RequestBy("GET", host+"/204")
 			assert.Equal(204, res.StatusCode)
 			assert.Equal("", res.Header.Get(HeaderContentEncoding))
 
-			res, _ = req.Get(host + "/205")
+			res, _ = RequestBy("GET", host+"/205")
 			assert.Equal(205, res.StatusCode)
 			assert.Equal("", res.Header.Get(HeaderContentEncoding))
 
-			res, _ = req.Get(host + "/304")
+			res, _ = RequestBy("GET", host+"/304")
 			assert.Equal(304, res.StatusCode)
 			assert.Equal("", res.Header.Get(HeaderContentEncoding))
 		})

--- a/middleware/favicon_test.go
+++ b/middleware/favicon_test.go
@@ -1,11 +1,11 @@
 package middleware
 
 import (
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
 
-	"github.com/mozillazg/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/teambition/gear"
 )
@@ -31,10 +31,7 @@ func PickError(res interface{}, err error) error {
 	return err
 }
 
-func NewRequst() *request.Request {
-	c := &http.Client{}
-	return request.NewRequest(c)
-}
+
 
 func TestGearMiddlewareFavicon(t *testing.T) {
 	assert.Panics(t, func() {
@@ -49,12 +46,10 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	srv := app.Start()
 	defer srv.Close()
 
-	req := NewRequst()
-
 	t.Run("GET", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Get("http://" + srv.Addr().String() + "/favicon.ico")
+		res, err = RequestBy("GET", "http://" + srv.Addr().String()+ "/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("image/x-icon", res.Header.Get(gear.HeaderContentType))
@@ -64,7 +59,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("HEAD", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Head("http://" + srv.Addr().String() + "/favicon.ico")
+		res, err = RequestBy("HEAD", "http://" + srv.Addr().String()+ "/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("image/x-icon", res.Header.Get(gear.HeaderContentType))
@@ -74,7 +69,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("OPTIONS", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Options("http://" + srv.Addr().String() + "/favicon.ico")
+		res, err = RequestBy("OPTIONS", "http://" + srv.Addr().String()+ "/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -85,7 +80,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("Other method", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Patch("http://" + srv.Addr().String() + "/favicon.ico")
+		res, err = RequestBy("PATCH", "http://" + srv.Addr().String()+"/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(405, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -96,7 +91,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("Other path", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Patch("http://" + srv.Addr().String() + "/abc")
+		res, err = RequestBy("PATCH", "http://" + srv.Addr().String()++ "/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		res.Body.Close()

--- a/middleware/favicon_test.go
+++ b/middleware/favicon_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -11,7 +10,27 @@ import (
 )
 
 // ----- Test Helpers -----
+type GearResponse struct {
+	*http.Response
+}
 
+var DefaultClient = &http.Client{}
+
+func RequestBy(method, url string) (*GearResponse, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := DefaultClient.Do(req)
+	return &GearResponse{res}, err
+}
+func NewRequst(method, url string) (*http.Request, error) {
+	return http.NewRequest(method, url, nil)
+}
+func DefaultClientDo(req *http.Request) (*GearResponse, error) {
+	res, err := DefaultClient.Do(req)
+	return &GearResponse{res}, err
+}
 func EqualPtr(t *testing.T, a, b interface{}) {
 	assert.Equal(t, reflect.ValueOf(a).Pointer(), reflect.ValueOf(b).Pointer())
 }
@@ -31,8 +50,6 @@ func PickError(res interface{}, err error) error {
 	return err
 }
 
-
-
 func TestGearMiddlewareFavicon(t *testing.T) {
 	assert.Panics(t, func() {
 		NewFavicon("../testdata/favicon1.ico")
@@ -49,7 +66,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("GET", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err = RequestBy("GET", "http://" + srv.Addr().String()+ "/favicon.ico")
+		res, err := RequestBy("GET", "http://"+srv.Addr().String()+"/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("image/x-icon", res.Header.Get(gear.HeaderContentType))
@@ -59,7 +76,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("HEAD", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err = RequestBy("HEAD", "http://" + srv.Addr().String()+ "/favicon.ico")
+		res, err := RequestBy("HEAD", "http://"+srv.Addr().String()+"/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("image/x-icon", res.Header.Get(gear.HeaderContentType))
@@ -69,7 +86,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("OPTIONS", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err = RequestBy("OPTIONS", "http://" + srv.Addr().String()+ "/favicon.ico")
+		res, err := RequestBy("OPTIONS", "http://"+srv.Addr().String()+"/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -80,7 +97,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("Other method", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err = RequestBy("PATCH", "http://" + srv.Addr().String()+"/favicon.ico")
+		res, err := RequestBy("PATCH", "http://"+srv.Addr().String()+"/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(405, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -91,7 +108,7 @@ func TestGearMiddlewareFavicon(t *testing.T) {
 	t.Run("Other path", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err = RequestBy("PATCH", "http://" + srv.Addr().String()++ "/favicon.ico")
+		res, err := RequestBy("PATCH", "http://"+srv.Addr().String()+"/abc")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		res.Body.Close()

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -77,8 +77,7 @@ func TestGearLogger(t *testing.T) {
 		srv := app.Start()
 		defer srv.Close()
 
-		req := NewRequst()
-		res, err := req.Get("http://" + srv.Addr().String())
+		res, err := RequestBy("GET", "http://"+srv.Addr().String())
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/html; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -107,8 +106,7 @@ func TestGearLogger(t *testing.T) {
 		srv := app.Start()
 		defer srv.Close()
 
-		req := NewRequst()
-		res, err := req.Get("http://" + srv.Addr().String())
+		res, err := RequestBy("GET", "http://"+srv.Addr().String())
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/html; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -137,8 +135,7 @@ func TestGearLogger(t *testing.T) {
 		srv := app.Start()
 		defer srv.Close()
 
-		req := NewRequst()
-		res, err := req.Post("http://" + srv.Addr().String())
+		res, err := RequestBy("POST", "http://"+srv.Addr().String())
 		assert.Nil(err)
 		assert.Equal(500, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))

--- a/middleware/static_test.go
+++ b/middleware/static_test.go
@@ -39,12 +39,10 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	srv := app.Start()
 	defer srv.Close()
 
-	req := NewRequst()
-
 	t.Run("GET", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Get("http://" + srv.Addr().String() + "/hello.html")
+		res, err := RequestBy("GET", "http://"+srv.Addr().String()+"/hello.html")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/html; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -54,7 +52,7 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	t.Run("GET with StripPrefix", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Get("http://" + srv.Addr().String() + "/static/hello.html")
+		res, err := RequestBy("GET", "http://"+srv.Addr().String()+"/static/hello.html")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/html; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -64,7 +62,7 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	t.Run("HEAD", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Head("http://" + srv.Addr().String() + "/hello.html")
+		res, err := RequestBy("HEAD", "http://"+srv.Addr().String()+"/hello.html")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/html; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -74,7 +72,7 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	t.Run("OPTIONS", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Options("http://" + srv.Addr().String() + "/hello.html")
+		res, err := RequestBy("OPTIONS", "http://"+srv.Addr().String()+"/hello.html")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -85,7 +83,7 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	t.Run("Other method", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Patch("http://" + srv.Addr().String() + "/hello.html")
+		res, err := RequestBy("PATCH", "http://"+srv.Addr().String()+"/hello.html")
 		assert.Nil(err)
 		assert.Equal(405, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -96,7 +94,7 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	t.Run("Other file", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Get("http://" + srv.Addr().String() + "/favicon.ico")
+		res, err := RequestBy("GET", "http://"+srv.Addr().String()+"/favicon.ico")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("image/x-icon", res.Header.Get(gear.HeaderContentType))
@@ -106,7 +104,9 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	t.Run("Should compress", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Get("http://" + srv.Addr().String() + "/README.md")
+		req, _ := NewRequst("GET", "http://"+srv.Addr().String()+"/README.md")
+		req.Header.Set("Accept-Encoding", "gzip, deflate")
+		res, err := DefaultClientDo(req)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))
@@ -117,7 +117,7 @@ func TestGearMiddlewareStatic(t *testing.T) {
 	t.Run("404", func(t *testing.T) {
 		assert := assert.New(t)
 
-		res, err := req.Get("http://" + srv.Addr().String() + "/none.html")
+		res, err := RequestBy("GET", "http://"+srv.Addr().String()+"/none.html")
 		assert.Nil(err)
 		assert.Equal(404, res.StatusCode)
 		assert.Equal("text/plain; charset=utf-8", res.Header.Get(gear.HeaderContentType))

--- a/router_test.go
+++ b/router_test.go
@@ -15,8 +15,6 @@ func TestGearRouter(t *testing.T) {
 		return app.Start()
 	}
 
-	req := NewRequst()
-
 	t.Run("router.Use, router.Handle", func(t *testing.T) {
 		assert := assert.New(t)
 
@@ -35,21 +33,21 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(0, called)
 		assert.Equal(444, res.StatusCode)
 		assert.Equal("", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/api")
+		res, err = RequestBy("GET", host+"/api")
 		assert.Nil(err)
 		assert.Equal(0, called)
 		assert.Equal(501, res.StatusCode)
 		assert.Equal("\"/api\" not implemented", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/api/users")
+		res, err = RequestBy("GET", host+"/api/users")
 		assert.Nil(err)
 		assert.Equal(1, called)
 		assert.Equal(200, res.StatusCode)
@@ -92,7 +90,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(3, called)
 		assert.Equal(200, res.StatusCode)
@@ -123,43 +121,43 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("GET", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Head(host)
+		res, err = RequestBy("HEAD", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Post(host)
+		res, err = RequestBy("POST", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("POST", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Put(host)
+		res, err = RequestBy("PUT", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("PUT", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Patch(host)
+		res, err = RequestBy("PATCH", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("PATCH", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Delete(host)
+		res, err = RequestBy("DELETE", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("DELETE", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Options(host)
+		res, err = RequestBy("OPTIONS", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("OPTIONS", PickRes(res.Text()).(string))
@@ -182,7 +180,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Options(host)
+		res, err := RequestBy("OPTIONS", host)
 		assert.Nil(err)
 		assert.Equal(204, res.StatusCode)
 		assert.Equal("GET, HEAD, POST, PUT", res.Header.Get(HeaderAllow))
@@ -217,7 +215,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(3, called)
 		assert.Equal(200, res.StatusCode)
@@ -237,7 +235,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(501, res.StatusCode)
 		assert.Equal("nosniff", res.Header.Get(HeaderXContentTypeOptions))
@@ -258,7 +256,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Put(host + "/abc")
+		res, err := RequestBy("PUT", host+"/abc")
 		assert.Nil(err)
 		assert.Equal(405, res.StatusCode)
 		assert.Equal("GET", res.Header.Get(HeaderAllow))
@@ -285,7 +283,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host + "/api/user/123")
+		res, err := RequestBy("GET", host+"/api/user/123")
 		assert.Nil(err)
 		assert.Equal(1, count)
 		assert.Equal(200, res.StatusCode)
@@ -310,7 +308,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host + "/api/:/123")
+		res, err := RequestBy("GET", host+"/api/:/123")
 		assert.Nil(err)
 		assert.Equal(1, count)
 		assert.Equal(200, res.StatusCode)
@@ -335,7 +333,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host + "/api/user/123")
+		res, err := RequestBy("GET", host+"/api/user/123")
 		assert.Nil(err)
 		assert.Equal(1, count)
 		assert.Equal(200, res.StatusCode)
@@ -360,13 +358,13 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host + "/api/user/abc")
+		res, err := RequestBy("GET", host+"/api/user/abc")
 		assert.Nil(err)
 		assert.Equal(0, count)
 		assert.Equal(501, res.StatusCode)
 		res.Body.Close()
 
-		res, err = req.Get(host + "/api/user/123")
+		res, err = RequestBy("GET", host+"/api/user/123")
 		assert.Nil(err)
 		assert.Equal(1, count)
 		assert.Equal(200, res.StatusCode)
@@ -394,21 +392,21 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host + "/api")
+		res, err := RequestBy("GET", host+"/api")
 		assert.Nil(err)
 		assert.Equal(1, count)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("OK", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/api/user/abc")
+		res, err = RequestBy("GET", host+"/api/user/abc")
 		assert.Nil(err)
 		assert.Equal(2, count)
 		assert.Equal(404, res.StatusCode)
 		assert.Equal("GET /api/user/abc", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Put(host + "/api")
+		res, err = RequestBy("PUT", host+"/api")
 		assert.Nil(err)
 		assert.Equal(3, count)
 		assert.Equal(404, res.StatusCode)
@@ -444,7 +442,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(3, called)
 		assert.Equal(200, res.StatusCode)
@@ -465,13 +463,13 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host + "/api/user/123")
+		res, err := RequestBy("GET", host+"/api/user/123")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("user123", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/API/User/Abc")
+		res, err = RequestBy("GET", host+"/API/User/Abc")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("UserAbc", PickRes(res.Text()).(string))
@@ -491,12 +489,12 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host + "/api/user/123")
+		res, err := RequestBy("GET", host+"/api/user/123")
 		assert.Nil(err)
 		assert.Equal(501, res.StatusCode)
 		res.Body.Close()
 
-		res, err = req.Get(host + "/Api/User/Abc")
+		res, err = RequestBy("GET", host+"/Api/User/Abc")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("UserAbc", PickRes(res.Text()).(string))
@@ -521,25 +519,25 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/")
+		res, err = RequestBy("GET", host+"/")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc/efg")
+		res, err = RequestBy("GET", host+"/abc/efg")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/efg", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc//efg")
+		res, err = RequestBy("GET", host+"/abc//efg")
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/efg", PickRes(res.Text()).(string))
 		res.Body.Close()
@@ -569,25 +567,25 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/")
+		res, err = RequestBy("GET", host+"/")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc/efg")
+		res, err = RequestBy("GET", host+"/abc/efg")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/efg", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc//efg")
+		res, err = RequestBy("GET", host+"/abc//efg")
 		assert.Equal(501, res.StatusCode)
 		res.Body.Close()
 
@@ -618,25 +616,25 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/")
+		res, err = RequestBy("GET", host+"/")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc/efg")
+		res, err = RequestBy("GET", host+"/abc/efg")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/efg", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc/efg/")
+		res, err = RequestBy("GET", host+"/abc/efg/")
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/efg", PickRes(res.Text()).(string))
 		res.Body.Close()
@@ -647,13 +645,13 @@ func TestGearRouter(t *testing.T) {
 		assert.Equal(301, rt.StatusCode)
 		assert.Equal("/abc/efg", rt.Header.Get("Location"))
 
-		res, err = req.Put(host + "/abc/xyz/")
+		res, err = RequestBy("PUT", host+"/abc/xyz/")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/xyz/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Put(host + "/abc/xyz")
+		res, err = RequestBy("PUT", host+"/abc/xyz")
 		assert.Equal(307, res.StatusCode)
 		assert.Equal("/abc/xyz/", res.Header.Get("Location"))
 		res.Body.Close()
@@ -687,25 +685,25 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/")
+		res, err = RequestBy("GET", host+"/")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc/efg")
+		res, err = RequestBy("GET", host+"/abc/efg")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/efg", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Get(host + "/abc/efg/")
+		res, err = RequestBy("GET", host+"/abc/efg/")
 		assert.Equal(501, res.StatusCode)
 		res.Body.Close()
 
@@ -713,13 +711,13 @@ func TestGearRouter(t *testing.T) {
 		err = r.Serve(ctx)
 		assert.Equal(501, err.(HTTPError).Status())
 
-		res, err = req.Put(host + "/abc/xyz/")
+		res, err = RequestBy("PUT", host+"/abc/xyz/")
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("/abc/xyz/", PickRes(res.Text()).(string))
 		res.Body.Close()
 
-		res, err = req.Put(host + "/abc/xyz")
+		res, err = RequestBy("PUT", host+"/abc/xyz")
 		assert.Equal(501, res.StatusCode)
 		res.Body.Close()
 
@@ -743,7 +741,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("OK", PickRes(res.Text()).(string))
@@ -765,7 +763,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(500, res.StatusCode)
 		assert.Equal("some error", PickRes(res.Text()).(string))
@@ -786,7 +784,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(200, res.StatusCode)
 		assert.Equal("OK", PickRes(res.Text()).(string))
@@ -807,7 +805,7 @@ func TestGearRouter(t *testing.T) {
 		defer srv.Close()
 		host := "http://" + srv.Addr().String()
 
-		res, err := req.Get(host)
+		res, err := RequestBy("GET", host)
 		assert.Nil(err)
 		assert.Equal(500, res.StatusCode)
 		assert.Equal("some error", PickRes(res.Text()).(string))


### PR DESCRIPTION
Remove third party library (mozillazg/request) and then use native http to test.