### PR TITLE
添加 secure 系列中间件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ script:
   - go test -coverprofile=cors.coverprofile ./middleware/cors
   - go test -coverprofile=favicon.coverprofile ./middleware/favicon
   - go test -coverprofile=static.coverprofile ./middleware/static
+  - go test -coverprofile=secure.coverprofile ./middleware/secure
   - gover
   - goveralls -coverprofile=gover.coverprofile -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ test:
 	go test --race ./middleware/cors
 	go test --race ./middleware/favicon
 	go test --race ./middleware/static
+	go test --race ./middleware/secure
 
 bench:
 	go test -bench=.
@@ -15,8 +16,10 @@ cover:
 	go test -coverprofile=cors.coverprofile ./middleware/cors
 	go test -coverprofile=favicon.coverprofile ./middleware/favicon
 	go test -coverprofile=static.coverprofile ./middleware/static
+	go test -coverprofile=secure.coverprofile ./middleware/secure
 	gover
 	go tool cover -html=gover.coverprofile
+	rm -f *.coverprofile
 
 doc:
 	godoc -http=:6060

--- a/const.go
+++ b/const.go
@@ -82,19 +82,25 @@ const (
 	HeaderUpgrade                       = "Upgrade"                          // Responses
 	HeaderVary                          = "Vary"                             // Responses
 	HeaderWWWAuthenticate               = "WWW-Authenticate"                 // Responses
+	HeaderPublicKeyPins                 = "Public-Key-Pins"                  // Responses
+	HeaderPublicKeyPinsReportOnly       = "Public-Key-Pins-Report-Only"      // Responses
+	HeaderRefererPolicy                 = "Referrer-Policy"                  // Responses
 
 	// Common Non-Standard Response Headers
-	HeaderXFrameOptions          = "X-Frame-Options"           // Responses
-	HeaderXXSSProtection         = "X-XSS-Protection"          // Responses
-	HeaderContentSecurityPolicy  = "Content-Security-Policy"   // Responses
-	HeaderXContentSecurityPolicy = "X-Content-Security-Policy" // Responses
-	HeaderXWebKitCSP             = "X-WebKit-CSP"              // Responses
-	HeaderXContentTypeOptions    = "X-Content-Type-Options"    // Responses
-	HeaderXPoweredBy             = "X-Powered-By"              // Responses
-	HeaderXUACompatible          = "X-UA-Compatible"           // Responses
-	HeaderXForwardedProto        = "X-Forwarded-Proto"         // Responses
-	HeaderXHTTPMethodOverride    = "X-HTTP-Method-Override"    // Responses
-	HeaderXForwardedFor          = "X-Forwarded-For"           // Responses
-	HeaderXRealIP                = "X-Real-IP"                 // Responses
-	HeaderXCSRFToken             = "X-CSRF-Token"              // Responses
+	HeaderXFrameOptions                   = "X-Frame-Options"                     // Responses
+	HeaderXXSSProtection                  = "X-XSS-Protection"                    // Responses
+	HeaderContentSecurityPolicy           = "Content-Security-Policy"             // Responses
+	HeaderContentSecurityPolicyReportOnly = "Content-Security-Policy-Report-Only" // Responses
+	HeaderXContentSecurityPolicy          = "X-Content-Security-Policy"           // Responses
+	HeaderXWebKitCSP                      = "X-WebKit-CSP"                        // Responses
+	HeaderXContentTypeOptions             = "X-Content-Type-Options"              // Responses
+	HeaderXPoweredBy                      = "X-Powered-By"                        // Responses
+	HeaderXUACompatible                   = "X-UA-Compatible"                     // Responses
+	HeaderXForwardedProto                 = "X-Forwarded-Proto"                   // Responses
+	HeaderXHTTPMethodOverride             = "X-HTTP-Method-Override"              // Responses
+	HeaderXForwardedFor                   = "X-Forwarded-For"                     // Responses
+	HeaderXRealIP                         = "X-Real-IP"                           // Responses
+	HeaderXCSRFToken                      = "X-CSRF-Token"                        // Responses
+	HeaderXDNSPrefetchControl             = "X-DNS-Prefetch-Control"              // Responses
+	HeaderXDownloadOptions                = "X-Download-Options"                  // Responses
 )

--- a/middleware/secure/secure.go
+++ b/middleware/secure/secure.go
@@ -1,0 +1,329 @@
+package secure
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/teambition/gear"
+)
+
+// FrameGuardAction represents a possible option of the "X-Frame-Options"
+// header.
+type FrameGuardAction string
+
+// "X-Frame-Options" header options.
+const (
+	FrameGuardActionDeny       FrameGuardAction = "DENY"
+	FrameGuardActionSameOrigin FrameGuardAction = "SAMEORIGIN"
+	FrameGuardActionAllowFrom  FrameGuardAction = "ALLOW-FROM"
+)
+
+// ReferrerPolicy represents a possible policy of the "Referrer-Policy"
+// header.
+type ReferrerPolicy string
+
+// Possible referrer policies.
+const (
+	ReferrerPolicyNoReferrer                  ReferrerPolicy = "no-referrer"
+	ReferrerPolicyWhenDowngrade               ReferrerPolicy = "no-referrer-when-downgrade"
+	ReferrerPolicyStrictOrigin                ReferrerPolicy = "strict-origin"
+	ReferrerPolicyStrictOriginWhenCrossOrigin ReferrerPolicy = "strict-origin-when-cross-origin"
+	ReferrerPolicySameOrigin                  ReferrerPolicy = "same-origin"
+	ReferrerPolicyOrigin                      ReferrerPolicy = "origin"
+	ReferrerPolicyOriginWhenCrossOrigin       ReferrerPolicy = "origin-when-cross-origin"
+	ReferrerPolicyUnsafeURL                   ReferrerPolicy = "unsafe-url"
+)
+
+var (
+	oldIERegex = regexp.MustCompile(`(?i)msie\s*(\d+)`)
+
+	defualtMiddleWares = []gear.Middleware{
+		DNSPrefetchControl(false),
+		HidePoweredBy(),
+		IENoOpen(),
+		NoSniff(),
+		XSSFilter(),
+		FrameGuard(FrameGuardActionSameOrigin),
+		StrictTransportSecurity(StrictTransportSecurityOptions{
+			MaxAge:            180 * 24 * time.Hour,
+			IncludeSubDomains: true,
+		}),
+	}
+)
+
+// Default provides protection for your Gear app by setting
+// various HTTP headers.
+// It equals:
+//
+// app.Use(DNSPrefetchControl(false))
+// app.Use(HidePoweredBy())
+// app.Use(IENoOpen())
+// app.Use(NoSniff())
+// app.Use(XSSFilter())
+// app.Use(FrameGuard(FrameGuardActionSameOrigin))
+// app.Use(StrictTransportSecurity(StrictTransportSecurityOptions{
+// 	MaxAge:            180 * 24 * time.Hour,
+// 	IncludeSubDomains: true,
+// }))
+//
+func Default() gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		for _, middleware := range defualtMiddleWares {
+			if err := middleware(ctx); err != nil {
+				// For now there are not any middleware that will return error.
+				return err
+			}
+		}
+
+		return
+	}
+}
+
+// DNSPrefetchControl controls browser DNS prefetching. And for potential
+// privacy implications, it should be disabled.
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Controlling_DNS_prefetching .
+func DNSPrefetchControl(allow bool) gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		if allow {
+			ctx.Set(gear.HeaderXDNSPrefetchControl, "on")
+		} else {
+			ctx.Set(gear.HeaderXDNSPrefetchControl, "off")
+		}
+
+		return
+	}
+}
+
+// FrameGuard mitigates clickjacking attacks by setting the X-Frame-Options
+// header. Because ALLOW-FROM option only allow one domain, so when action is
+// FrameGuardActionAllowFrom, you should only give one domain at the second
+// parameter, and others will be ignored.
+// See https://en.wikipedia.org/wiki/Clickjacking and https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options .
+func FrameGuard(action FrameGuardAction, domains ...string) gear.Middleware {
+	if action == FrameGuardActionAllowFrom && len(domains) != 1 {
+		panic("secure: 'X-Frame-Options: ALLOW-FROM' only support one domain")
+	}
+
+	return func(ctx *gear.Context) (err error) {
+		switch action {
+		case FrameGuardActionDeny:
+			ctx.Set(gear.HeaderXFrameOptions, "DENY")
+		case FrameGuardActionSameOrigin:
+			ctx.Set(gear.HeaderXFrameOptions, "SAMEORIGIN")
+		case FrameGuardActionAllowFrom:
+			ctx.Set(gear.HeaderXFrameOptions, "ALLOW-FROM "+domains[0])
+		}
+
+		return
+	}
+}
+
+// HidePoweredBy removes the X-Powered-By header to make it slightly harder for
+// attackers to see what potentially-vulnerable technology powers your site.
+func HidePoweredBy() gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		ctx.After(func() {
+			ctx.Res.Header().Del(gear.HeaderXPoweredBy)
+		})
+
+		return
+	}
+}
+
+// PublicKeyPinningOptions is public key pinning middleware options.
+type PublicKeyPinningOptions struct {
+	MaxAge            time.Duration
+	Sha256s           []string
+	ReportURI         string
+	IncludeSubdomains bool
+	ReportOnly        bool
+}
+
+// PublicKeyPinning helps you set the Public-Key-Pins header to prevent
+// person-in-the-middle attacks.
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning .
+func PublicKeyPinning(options PublicKeyPinningOptions) gear.Middleware {
+	if len(options.Sha256s) == 0 {
+		panic(fmt.Errorf("secure: empty Public-Key-Pins sha256s"))
+	}
+
+	return func(ctx *gear.Context) (err error) {
+		publicKeyPins := ""
+
+		for _, sha256 := range options.Sha256s {
+			publicKeyPins += fmt.Sprintf(`pin-sha256="%v";`, sha256)
+		}
+
+		if options.MaxAge != 0 {
+			publicKeyPins += fmt.Sprintf("max-age=%.f;", options.MaxAge.Seconds())
+		}
+
+		if options.IncludeSubdomains {
+			publicKeyPins += "includeSubDomains;"
+		}
+
+		if options.ReportURI != "" {
+			publicKeyPins += fmt.Sprintf(`report-uri="%v"`, options.ReportURI)
+		}
+
+		if options.ReportOnly {
+			ctx.Set(gear.HeaderPublicKeyPinsReportOnly, publicKeyPins)
+		} else {
+			ctx.Set(gear.HeaderPublicKeyPins, publicKeyPins)
+		}
+
+		return
+	}
+}
+
+// StrictTransportSecurityOptions is the StrictTransportSecurity middleware
+// options.
+type StrictTransportSecurityOptions struct {
+	MaxAge            time.Duration
+	IncludeSubDomains bool
+	Preload           bool
+}
+
+// StrictTransportSecurity sets the Strict-Transport-Security header to keep
+// your users on HTTPS.
+// See https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security .
+func StrictTransportSecurity(options StrictTransportSecurityOptions) gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		val := fmt.Sprintf("max-age=%.f;", options.MaxAge.Seconds())
+
+		if options.IncludeSubDomains {
+			val += "includeSubDomains;"
+		}
+
+		if options.Preload {
+			val += "preload;"
+		}
+
+		ctx.Set(gear.HeaderStrictTransportSecurity, val)
+
+		return
+	}
+}
+
+// IENoOpen sets the X-Download-Options to prevent Internet Explorer from
+// executing downloads in your site’s context.
+// See https://blogs.msdn.microsoft.com/ie/2008/07/02/ie8-security-part-v-comprehensive-protection/ .
+func IENoOpen() gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		ctx.Set(gear.HeaderXDownloadOptions, "noopen")
+
+		return
+	}
+}
+
+// NoSniff helps prevent browsers from trying to guess (“sniff”) the MIME type,
+// which can have security implications. It does this by setting the
+// X-Content-Type-Options header to nosniff.
+// See https://blog.fox-it.com/2012/05/08/mime-sniffing-feature-or-vulnerability/ .
+func NoSniff() gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		ctx.Set(gear.HeaderXContentTypeOptions, "nosniff")
+
+		return
+	}
+}
+
+// SetReferrerPolicy controls the behavior of the Referer header by setting the
+// Referrer-Policy header.
+// See https://www.w3.org/TR/referrer-policy/#referrer-policy-header .
+func SetReferrerPolicy(policy ReferrerPolicy) gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		ctx.Set(gear.HeaderRefererPolicy, string(policy))
+
+		return
+	}
+}
+
+// XSSFilter sets the X-XSS-Protection header to "1; mode=block" to prevent
+// reflected XSS attacks. Because on old versions of IE (<9), this will cause
+// some even worse security vulnerabilities, so it will set the header to "0"
+// for old IE.
+// See https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter/ .
+func XSSFilter() gear.Middleware {
+	return func(ctx *gear.Context) error {
+		ieVersion, err := getIEVersionFromUA(ctx.Get(gear.HeaderUserAgent))
+
+		if err == nil && ieVersion < 9 {
+			ctx.Set(gear.HeaderXXSSProtection, "0")
+		} else {
+			ctx.Set(gear.HeaderXXSSProtection, "1; mode=block")
+		}
+
+		return nil
+	}
+}
+
+func getIEVersionFromUA(ua string) (float64, error) {
+	matches := oldIERegex.FindStringSubmatch(ua)
+
+	if len(matches) <= 1 {
+		return 0, errors.New("secure: Not IE UserAgent")
+	}
+
+	return strconv.ParseFloat(matches[1], 64)
+}
+
+// CSPDirectives represents all valid directives that the
+// "Content-Security-Policy" header is made up of.
+type CSPDirectives struct {
+	DefaultSrc     []string `csp:"default-src"`
+	ScriptSrc      []string `csp:"script-src"`
+	StyleSrc       []string `csp:"style-src"`
+	ImgSrc         []string `csp:"img-src"`
+	ConnectSrc     []string `csp:"connect-src"`
+	FontSrc        []string `csp:"font-src"`
+	ObjectSrc      []string `csp:"object-src"`
+	MediaSrc       []string `csp:"media-src"`
+	FrameSrc       []string `csp:"frame-src"`
+	ChildSrc       []string `csp:"child-src"`
+	Sandbox        []string `csp:"sandbox"`
+	FormAction     []string `csp:"form-action"`
+	FrameAncestors []string `csp:"frame-ancestors"`
+	PluginTypes    []string `csp:"plugin-types"`
+	ReportURI      string   `csp:"report-uri"`
+	ReportOnly     bool
+}
+
+// ContentSecurityPolicy (CSP) sets the Content-Security-Policy header which
+// can help protect against malicious injection of JavaScript, CSS, plugins,
+// and more.
+// See https://content-security-policy.com .
+func ContentSecurityPolicy(directives CSPDirectives) gear.Middleware {
+	return func(ctx *gear.Context) (err error) {
+		elems := reflect.ValueOf(&directives).Elem()
+		csp := ""
+
+		for i := 0; i < elems.NumField(); i++ {
+			val := elems.Field(i)
+			typ := elems.Type().Field(i)
+
+			if val.Kind() != reflect.Slice || val.Len() == 0 {
+				continue
+			}
+
+			csp += (typ.Tag.Get("csp") + " " + strings.Join(val.Interface().([]string), " ") + ";")
+		}
+
+		if directives.ReportURI != "" {
+			csp += fmt.Sprintf("report-uri %v;", directives.ReportURI)
+		}
+
+		if directives.ReportOnly {
+			ctx.Set(gear.HeaderContentSecurityPolicyReportOnly, csp)
+		} else {
+			ctx.Set(gear.HeaderContentSecurityPolicy, csp)
+		}
+
+		return
+	}
+}

--- a/middleware/secure/secure_test.go
+++ b/middleware/secure/secure_test.go
@@ -1,0 +1,426 @@
+package secure
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/teambition/gear"
+)
+
+var DefaultClient = &http.Client{}
+
+func TestGearMiddlewareSecure(t *testing.T) {
+	t.Run("DNSPrefetchControl", func(t *testing.T) {
+		t.Run(`Should set X-DNS-Prefetch-Control header to "on" when set allow to true`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(DNSPrefetchControl(true))
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("on", res.Header.Get(gear.HeaderXDNSPrefetchControl))
+		})
+
+		t.Run(`Should set X-DNS-Prefetch-Control header to "off" when set allow to false`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(DNSPrefetchControl(false))
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("off", res.Header.Get(gear.HeaderXDNSPrefetchControl))
+		})
+	})
+
+	t.Run("FrameGuard", func(t *testing.T) {
+		t.Run(`Should set X-Frame-Options header to "DENY" when action is FrameGuardActionDeny`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(FrameGuard(FrameGuardActionDeny))
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("DENY", res.Header.Get(gear.HeaderXFrameOptions))
+		})
+
+		t.Run(`Should set X-Frame-Options header to "SAMEORIGIN" when action is FrameGuardActionSameOrigin`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(FrameGuard(FrameGuardActionSameOrigin))
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("SAMEORIGIN", res.Header.Get(gear.HeaderXFrameOptions))
+		})
+
+		t.Run(`Should set X-Frame-Options header to "ALLOW-FROM Domain" when action is FrameGuardActionAllowFrom`, func(t *testing.T) {
+			assert := assert.New(t)
+			domain := "test.org"
+
+			app := getAppWithMiddleware(FrameGuard(FrameGuardActionAllowFrom, domain))
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("ALLOW-FROM "+domain, res.Header.Get(gear.HeaderXFrameOptions))
+		})
+
+		t.Run(`Should panic when action is FrameGuardActionAllowFrom but no domain`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Panics(func() {
+				getAppWithMiddleware(FrameGuard(FrameGuardActionAllowFrom))
+			})
+		})
+	})
+
+	t.Run("HidePoweredBy", func(t *testing.T) {
+		t.Run(`Should remove X-Prowered-By header`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(HidePoweredBy())
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Empty(res.Header.Get(gear.HeaderXPoweredBy))
+		})
+	})
+
+	t.Run("PublicKeyPinning", func(t *testing.T) {
+		t.Run("Should enable public key pinning", func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(PublicKeyPinning(PublicKeyPinningOptions{
+				MaxAge: 100 * time.Second,
+				Sha256s: []string{
+					"cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs=", "M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE",
+				},
+				ReportURI:         "test.org",
+				IncludeSubdomains: true,
+			}))
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal(`pin-sha256="cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs=";pin-sha256="M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE";max-age=100;includeSubDomains;report-uri="test.org"`, res.Header.Get(gear.HeaderPublicKeyPins))
+		})
+
+		t.Run("Should enable public key pinning and report only", func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(PublicKeyPinning(PublicKeyPinningOptions{
+				MaxAge: 100 * time.Second,
+				Sha256s: []string{
+					"cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs=", "M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE",
+				},
+				ReportURI:         "test.org",
+				IncludeSubdomains: true,
+				ReportOnly:        true,
+			}))
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal(`pin-sha256="cUPcTAZWKaASuYWhhneDttWpY3oBAkE3h2+soZS7sWs=";pin-sha256="M8HztCzM3elUxkcjR2S5P4hhyBNf6lHkmjAHKhpGPWE";max-age=100;includeSubDomains;report-uri="test.org"`, res.Header.Get(gear.HeaderPublicKeyPinsReportOnly))
+		})
+
+		t.Run(`Should panic when sha256s is empty`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Panics(func() {
+				getAppWithMiddleware(PublicKeyPinning(PublicKeyPinningOptions{
+					Sha256s: []string{},
+				}))
+			})
+		})
+	})
+
+	t.Run("StrictTransportSecurity", func(t *testing.T) {
+		t.Run("Should enable strict transport security", func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(StrictTransportSecurity(StrictTransportSecurityOptions{
+				MaxAge:            100 * time.Second,
+				IncludeSubDomains: true,
+				Preload:           true,
+			}))
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("max-age=100;includeSubDomains;preload;", res.Header.Get(gear.HeaderStrictTransportSecurity))
+		})
+	})
+
+	t.Run("IENoOpen", func(t *testing.T) {
+		t.Run(`Should set X-Download-Options header to "noopen"`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(IENoOpen())
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("noopen", res.Header.Get(gear.HeaderXDownloadOptions))
+		})
+	})
+
+	t.Run("NoSniff", func(t *testing.T) {
+		t.Run(`Should set X-Content-Type-Options header to "nosniff"`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(NoSniff())
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("nosniff", res.Header.Get(gear.HeaderXContentTypeOptions))
+		})
+	})
+
+	t.Run("SetReferrerPolicy", func(t *testing.T) {
+		t.Run("Should set Referrer-Policy header to given policy", func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(SetReferrerPolicy(ReferrerPolicyOrigin))
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal(string(ReferrerPolicyOrigin), res.Header.Get(gear.HeaderRefererPolicy))
+		})
+	})
+
+	t.Run("XSSFilter", func(t *testing.T) {
+		t.Run(`Should set X-XSS-Protection header to "0" on old IE (<9)`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(XSSFilter())
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			// IE 8
+			req.Header.Set(gear.HeaderUserAgent, "Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)")
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("0", res.Header.Get(gear.HeaderXXSSProtection))
+		})
+
+		t.Run(`Should set X-XSS-Protection header to "1; mode=block" on new IE (>=9)`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(XSSFilter())
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			// IE 9
+			req.Header.Set(gear.HeaderUserAgent, "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))")
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("1; mode=block", res.Header.Get(gear.HeaderXXSSProtection))
+		})
+
+		t.Run(`Should set X-XSS-Protection header to "1; mode=block" when UA is not IE`, func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(XSSFilter())
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			// Firefox
+			req.Header.Set(gear.HeaderUserAgent, "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1")
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("1; mode=block", res.Header.Get(gear.HeaderXXSSProtection))
+		})
+	})
+
+	t.Run("ContentSecurityPolicy", func(t *testing.T) {
+		t.Run("Should set all given directives", func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(ContentSecurityPolicy(CSPDirectives{
+				DefaultSrc: []string{"'slef'", "www.google-analytics.com"},
+				Sandbox:    []string{"allow-forms", "allow-scripts"},
+				ReportURI:  "/some-report-uri",
+			}))
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("default-src 'slef' www.google-analytics.com;sandbox allow-forms allow-scripts;report-uri /some-report-uri;", res.Header.Get(gear.HeaderContentSecurityPolicy))
+		})
+
+		t.Run("Should set all given directives but report only", func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(ContentSecurityPolicy(CSPDirectives{
+				DefaultSrc: []string{"'slef'", "www.google-analytics.com"},
+				Sandbox:    []string{"allow-forms", "allow-scripts"},
+				ReportURI:  "/some-report-uri",
+				ReportOnly: true,
+			}))
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("default-src 'slef' www.google-analytics.com;sandbox allow-forms allow-scripts;report-uri /some-report-uri;", res.Header.Get(gear.HeaderContentSecurityPolicyReportOnly))
+		})
+	})
+
+	t.Run("Default", func(t *testing.T) {
+		t.Run("Should run default middlewares", func(t *testing.T) {
+			assert := assert.New(t)
+
+			app := getAppWithMiddleware(Default())
+
+			srv := app.Start()
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, "http://"+srv.Addr().String(), nil)
+
+			assert.Nil(err)
+
+			res, err := DefaultClient.Do(req)
+
+			assert.Nil(err)
+			assert.Equal("off", res.Header.Get(gear.HeaderXDNSPrefetchControl))
+			assert.Empty(res.Header.Get(gear.HeaderXPoweredBy))
+			assert.Equal("noopen", res.Header.Get(gear.HeaderXDownloadOptions))
+			assert.Equal("nosniff", res.Header.Get(gear.HeaderXContentTypeOptions))
+			assert.Equal("1; mode=block", res.Header.Get(gear.HeaderXXSSProtection))
+			assert.Equal("max-age=15552000;includeSubDomains;", res.Header.Get(gear.HeaderStrictTransportSecurity))
+		})
+	})
+}
+
+func getAppWithMiddleware(middleware gear.Middleware) *gear.App {
+	app := gear.New()
+	app.Use(middleware)
+	app.Use(func(ctx *gear.Context) error {
+		ctx.Set(gear.HeaderXPoweredBy, "Gear")
+		return ctx.HTML(200, "OK")
+	})
+
+	return app
+}


### PR DESCRIPTION
添加 secure 系列中间件:
- DNSPrefetchControl
- FrameGuard
- HidePoweredBy
- PublicKeyPinning
- StrictTransportSecurity
- IENoOpen
- NoSniff
- XSSFilter
- ContentSecurityPolicy