### PR TITLE
first demo run error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ package main
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/teambition/gear"
 	"github.com/teambition/gear/logging"
 )


### PR DESCRIPTION
the [first demo](https://github.com/teambition/gear#demo) of README run error.
```
# command-line-arguments
./test.go:5: imported and not used: "os"
```
update it.