### PR TITLE
fix: cors not set Access-Control-Allow-Credentials header

### DIFF
--- a/middleware/cors/cors.go
+++ b/middleware/cors/cors.go
@@ -65,7 +65,7 @@ func New(options ...Options) gear.Middleware {
 		opts.AllowOriginsValidator = func(origin string, _ *gear.Context) (allowOrigin string) {
 			for _, o := range opts.AllowOrigins {
 				if o == origin || o == "*" {
-					allowOrigin = o
+					allowOrigin = origin
 					break
 				}
 			}
@@ -89,7 +89,7 @@ func New(options ...Options) gear.Middleware {
 			return ctx.Error(&gear.Error{Code: http.StatusForbidden,
 				Msg: fmt.Sprintf("Origin: %v is not allowed", origin)})
 		}
-		if allowOrigin != "*" && opts.Credentials {
+		if opts.Credentials {
 			// when responding to a credentialed request, server must specify a
 			// domain, and cannot use wild carding.
 			// See *important note* in https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials .

--- a/middleware/cors/cors_test.go
+++ b/middleware/cors/cors_test.go
@@ -136,8 +136,8 @@ func TestGearMiddlewareCORS(t *testing.T) {
 
 			assert.Nil(err)
 			assert.Equal("Origin", res.Header.Get(gear.HeaderVary))
-			assert.Equal("*", res.Header.Get(gear.HeaderAccessControlAllowOrigin))
-			assert.Equal("", res.Header.Get(gear.HeaderAccessControlAllowCredentials))
+			assert.Equal("test.org", res.Header.Get(gear.HeaderAccessControlAllowOrigin))
+			assert.Equal("true", res.Header.Get(gear.HeaderAccessControlAllowCredentials))
 			assert.Equal(strings.Join(defaultAllowMethods, ", "),
 				res.Header.Get(gear.HeaderAccessControlAllowMethods))
 		})


### PR DESCRIPTION
when `Credentials = true`, should always set `Access-Control-Allow-Credentials`, for [detail](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Credentials).

but now, when set `AllowOrigin = []string{"*"}, Credentials = true`, and in other site, request with `XMLHttpRequest.withCredentials = true`,  the `Access-Control-Allow-Origin` is "*" and response header `Access-Control-Allow-Credentials` will not set, this will cause a error in browser.

When responding to a credentialed request, the server must specify an origin in the value of the Access-Control-Allow-Origin header, instead of specifying the "*" wildcard.

code below will recur this bug.

server.go
```go
package main 

import (
  "github.com/teambition/gear"
  "github.com/teambition/gear/middleware/cors"
  "github.com/teambition/gear/logging"
)

func main() {
  app := gear.New()

  // Add logging middleware
  app.UseHandler(logging.Default())
  app.Use(cors.New(cors.Options{
    AllowOrigins: []string{"*"},
    Credentials: true,
  }))

  // Add router middleware
  router := gear.NewRouter()
  router.Get("/a", func(ctx *gear.Context) error {
    return ctx.HTML(200, "<h1>Hello, Gear!</h1>")
  })
  app.UseHandler(router)
  app.Error(app.Listen(":8080"))
}
```

crossorigin script
```js
var invocation = new XMLHttpRequest();
var url = 'http://localhost:8080/a';

invocation.open('GET', url, true);
invocation.withCredentials = true;
invocation.onreadystatechange = function() {
    if (invocation.readyState === XMLHttpRequest.DONE) {
        if (invocation.status === 200) {
            console.log(invocation.responseText);
        } else {
            console.log('There was a problem with the request.');
        }
    }
};
invocation.send();
```

this pr will cause `Access-Control-Allow-Origin` will always be a specified domain, even if you set `AllowOrigins = []string{"*"}`,  that should be enough(to my opinion).