### PR TITLE
Feature/add parse query

### DIFF
--- a/app.go
+++ b/app.go
@@ -27,6 +27,21 @@ type Renderer interface {
 	Render(ctx *Context, w io.Writer, name string, data interface{}) error
 }
 
+// QueryParser interface is used by ctx.ParseQuery. Default to:
+//  app.Set(gear.SetQueryParser, DefaultQueryParser)
+//
+type QueryParser interface {
+	Parse(val map[string][]string, body interface{}) error
+}
+
+// DefaultBodyParser is default QueryParser type.
+type DefaultQueryParser struct{}
+
+// Parse implemented QueryParser interface.
+func (d DefaultQueryParser) Parse(val map[string][]string, body interface{}) error {
+	return FormToStruct(val, body)
+}
+
 // BodyParser interface is used by ctx.ParseBody. Default to:
 //  app.Set(gear.SetBodyParser, DefaultBodyParser(1<<20))
 //
@@ -99,6 +114,7 @@ type App struct {
 	keys        []string
 	renderer    Renderer
 	bodyParser  BodyParser
+	queryParser QueryParser
 	compress    Compressible  // Default to nil, do not compress response content.
 	timeout     time.Duration // Default to 0, no time out.
 	logger      *log.Logger
@@ -120,6 +136,7 @@ func New() *App {
 	}
 	app.Set(SetEnv, env)
 	app.Set(SetBodyParser, DefaultBodyParser(2<<20)) // 2MB
+	app.Set(SetQueryParser, DefaultQueryParser{})
 	app.Set(SetLogger, log.New(os.Stderr, "", log.LstdFlags))
 	return app
 }
@@ -141,6 +158,10 @@ const (
 	// It will be used by `ctx.ParseBody`, value should implements `gear.BodyParser` interface, default to:
 	//  app.Set(gear.SetBodyParser, gear.DefaultBodyParser(1<<20))
 	SetBodyParser appSetting = iota
+
+	// It will be used by `ctx.ParseQuery`, value should implements `gear.QueryParser` interface, default to:
+	//  app.Set(gear.SetQueryParser, gear.DefaultQueryParser)
+	SetQueryParser
 
 	// Enable compress for response, value should implements `gear.Compressible` interface, no default value.
 	// Example:
@@ -188,6 +209,12 @@ func (app *App) Set(key, val interface{}) {
 				panic(Err.WithMsg("SetBodyParser setting must implemented gear.BodyParser interface"))
 			} else {
 				app.bodyParser = bodyParser
+			}
+		case SetQueryParser:
+			if queryParser, ok := val.(QueryParser); !ok {
+				panic(Err.WithMsg("SetQueryParser setting must implemented gear.QueryParser interface"))
+			} else {
+				app.queryParser = queryParser
 			}
 		case SetCompress:
 			if compress, ok := val.(Compressible); !ok {

--- a/app.go
+++ b/app.go
@@ -31,15 +31,15 @@ type Renderer interface {
 //  app.Set(gear.SetUrlParser, DefaultUrlParser)
 //
 type UrlParser interface {
-	Parse(val map[string][]string, body interface{}) error
+	Parse(val map[string][]string, body interface{}, tag string) error
 }
 
 // DefaultUrlParser is default UrlParser type.
 type DefaultUrlParser struct{}
 
 // Parse implemented UrlParser interface.
-func (d DefaultUrlParser) Parse(val map[string][]string, body interface{}) error {
-	return FormToStruct(val, body)
+func (d DefaultUrlParser) Parse(val map[string][]string, body interface{}, tag string) error {
+	return FormToStruct(val, body, tag)
 }
 
 // BodyParser interface is used by ctx.ParseBody. Default to:
@@ -76,7 +76,7 @@ func (d DefaultBodyParser) Parse(buf []byte, body interface{}, mediaType, charse
 	case MIMEApplicationForm:
 		val, err := url.ParseQuery(string(buf))
 		if err == nil {
-			err = FormToStruct(val, body)
+			err = FormToStruct(val, body, "form")
 		}
 		return err
 	}

--- a/app.go
+++ b/app.go
@@ -27,18 +27,18 @@ type Renderer interface {
 	Render(ctx *Context, w io.Writer, name string, data interface{}) error
 }
 
-// QueryParser interface is used by ctx.ParseQuery. Default to:
-//  app.Set(gear.SetQueryParser, DefaultQueryParser)
+// UrlParser interface is used by ctx.ParseUrl. Default to:
+//  app.Set(gear.SetUrlParser, DefaultUrlParser)
 //
-type QueryParser interface {
+type UrlParser interface {
 	Parse(val map[string][]string, body interface{}) error
 }
 
-// DefaultBodyParser is default QueryParser type.
-type DefaultQueryParser struct{}
+// DefaultUrlParser is default UrlParser type.
+type DefaultUrlParser struct{}
 
-// Parse implemented QueryParser interface.
-func (d DefaultQueryParser) Parse(val map[string][]string, body interface{}) error {
+// Parse implemented UrlParser interface.
+func (d DefaultUrlParser) Parse(val map[string][]string, body interface{}) error {
 	return FormToStruct(val, body)
 }
 
@@ -114,7 +114,7 @@ type App struct {
 	keys        []string
 	renderer    Renderer
 	bodyParser  BodyParser
-	queryParser QueryParser
+	urlParser   UrlParser
 	compress    Compressible  // Default to nil, do not compress response content.
 	timeout     time.Duration // Default to 0, no time out.
 	logger      *log.Logger
@@ -136,7 +136,7 @@ func New() *App {
 	}
 	app.Set(SetEnv, env)
 	app.Set(SetBodyParser, DefaultBodyParser(2<<20)) // 2MB
-	app.Set(SetQueryParser, DefaultQueryParser{})
+	app.Set(SetUrlParser, DefaultUrlParser{})
 	app.Set(SetLogger, log.New(os.Stderr, "", log.LstdFlags))
 	return app
 }
@@ -159,9 +159,9 @@ const (
 	//  app.Set(gear.SetBodyParser, gear.DefaultBodyParser(1<<20))
 	SetBodyParser appSetting = iota
 
-	// It will be used by `ctx.ParseQuery`, value should implements `gear.QueryParser` interface, default to:
-	//  app.Set(gear.SetQueryParser, gear.DefaultQueryParser)
-	SetQueryParser
+	// It will be used by `ctx.ParseQuery`, value should implements `gear.UrlParser` interface, default to:
+	//  app.Set(gear.SetUrlParser, gear.DefaultUrlParser)
+	SetUrlParser
 
 	// Enable compress for response, value should implements `gear.Compressible` interface, no default value.
 	// Example:
@@ -210,11 +210,11 @@ func (app *App) Set(key, val interface{}) {
 			} else {
 				app.bodyParser = bodyParser
 			}
-		case SetQueryParser:
-			if queryParser, ok := val.(QueryParser); !ok {
-				panic(Err.WithMsg("SetQueryParser setting must implemented gear.QueryParser interface"))
+		case SetUrlParser:
+			if urlParser, ok := val.(UrlParser); !ok {
+				panic(Err.WithMsg("SetUrlParser setting must implemented gear.UrlParser interface"))
 			} else {
-				app.queryParser = queryParser
+				app.urlParser = urlParser
 			}
 		case SetCompress:
 			if compress, ok := val.(Compressible); !ok {

--- a/context.go
+++ b/context.go
@@ -392,7 +392,7 @@ func (ctx *Context) ParseBody(body BodyTemplate) error {
 	return body.Validate()
 }
 
-// ParseQuery parses query with QueryParser, stores the result in the value
+// ParseUrl parses query with UrlParser, stores the result in the value
 // pointed to by BodyTemplate body, and validate it.
 //
 // Define a BodyTemplate type in some API:
@@ -414,11 +414,20 @@ func (ctx *Context) ParseBody(body BodyTemplate) error {
 //  	return err
 //  }
 //
-func (ctx *Context) ParseQuery(body BodyTemplate) error {
-	if ctx.app.queryParser == nil {
-		return Err.WithMsg("queryParser not registered")
+func (ctx *Context) ParseUrl(body BodyTemplate) error {
+	if ctx.app.urlParser == nil {
+		return Err.WithMsg("urlParser not registered")
 	}
-	if err := ctx.app.queryParser.Parse(ctx.Req.URL.Query(), body); err != nil {
+
+	urlValues := ctx.Req.URL.Query()
+	if res, _ := ctx.Any(paramsKey); res != nil {
+		if params, ok := res.(map[string]string); ok {
+			for k, v := range params {
+				urlValues.Set(k, v)
+			}
+		}
+	}
+	if err := ctx.app.urlParser.Parse(urlValues, body); err != nil {
 		return err
 	}
 

--- a/context.go
+++ b/context.go
@@ -392,6 +392,39 @@ func (ctx *Context) ParseBody(body BodyTemplate) error {
 	return body.Validate()
 }
 
+// ParseQuery parses query with BodyParser, stores the result in the value
+// pointed to by BodyTemplate body, and validate it.
+//
+// Defaine a BodyTemplate type in some API:
+//  type jsonQueryTemplate struct {
+//  	ID   string `json:"id" form:"id"`
+//  	Pass string `json:"pass" form:"pass"`
+//  }
+//
+//  func (b *jsonQueryTemplate) Validate() error {
+//  	if len(b.ID) < 3 || len(b.Pass) < 6 {
+//  		return ErrBadRequest.WithMsg("invalid id or pass")
+//  	}
+//  	return nil
+//  }
+//
+// Use it in middleware:
+//  body := jsonBodyTemplate{}
+//  if err := ctx.ParseQuery(&body) {
+//  	return err
+//  }
+//
+func (ctx *Context) ParseQuery(body BodyTemplate) error {
+	if ctx.app.queryParser == nil {
+		return Err.WithMsg("queryParser not registered")
+	}
+	if err := ctx.app.queryParser.Parse(ctx.Req.URL.Query(), body); err != nil {
+		return err
+	}
+
+	return body.Validate()
+}
+
 // Get retrieves data from the request Header.
 func (ctx *Context) Get(key string) string {
 	return ctx.Req.Header.Get(key)

--- a/context.go
+++ b/context.go
@@ -342,7 +342,7 @@ func (ctx *Context) QueryAll(name string) []string {
 // pointed to by BodyTemplate body, and validate it.
 // DefaultBodyParser support JSON, Form and XML.
 //
-// Defaine a BodyTemplate type in some API:
+// Define a BodyTemplate type in some API:
 //  type jsonBodyTemplate struct {
 //  	ID   string `json:"id" form:"id"`
 //  	Pass string `json:"pass" form:"pass"`
@@ -392,10 +392,10 @@ func (ctx *Context) ParseBody(body BodyTemplate) error {
 	return body.Validate()
 }
 
-// ParseQuery parses query with BodyParser, stores the result in the value
+// ParseQuery parses query with QueryParser, stores the result in the value
 // pointed to by BodyTemplate body, and validate it.
 //
-// Defaine a BodyTemplate type in some API:
+// Define a BodyTemplate type in some API:
 //  type jsonQueryTemplate struct {
 //  	ID   string `json:"id" form:"id"`
 //  	Pass string `json:"pass" form:"pass"`
@@ -409,7 +409,7 @@ func (ctx *Context) ParseBody(body BodyTemplate) error {
 //  }
 //
 // Use it in middleware:
-//  body := jsonBodyTemplate{}
+//  body := jsonQueryTemplate{}
 //  if err := ctx.ParseQuery(&body) {
 //  	return err
 //  }

--- a/context.go
+++ b/context.go
@@ -419,15 +419,20 @@ func (ctx *Context) ParseUrl(body BodyTemplate) error {
 		return Err.WithMsg("urlParser not registered")
 	}
 
-	urlValues := ctx.Req.URL.Query()
+	if err := ctx.app.urlParser.Parse(ctx.Req.URL.Query(), body, "query"); err != nil {
+		return err
+	}
+
+	paramValues := make(map[string][]string)
 	if res, _ := ctx.Any(paramsKey); res != nil {
 		if params, ok := res.(map[string]string); ok {
 			for k, v := range params {
-				urlValues.Set(k, v)
+				paramValues[k] = []string{v}
 			}
 		}
 	}
-	if err := ctx.app.urlParser.Parse(urlValues, body); err != nil {
+
+	if err := ctx.app.urlParser.Parse(paramValues, body, "param"); err != nil {
 		return err
 	}
 

--- a/context.go
+++ b/context.go
@@ -397,8 +397,8 @@ func (ctx *Context) ParseBody(body BodyTemplate) error {
 //
 // Define a BodyTemplate type in some API:
 //  type jsonQueryTemplate struct {
-//  	ID   string `json:"id" form:"id"`
-//  	Pass string `json:"pass" form:"pass"`
+//  	ID   string `json:"id" query:"id"`
+//  	Pass string `json:"pass" query:"pass"`
 //  }
 //
 //  func (b *jsonQueryTemplate) Validate() error {

--- a/util.go
+++ b/util.go
@@ -198,7 +198,7 @@ func ErrorWithStack(val interface{}, skip ...int) *Error {
 }
 
 // FormToStruct converts form values into struct object.
-func FormToStruct(form map[string][]string, target interface{}) (err error) {
+func FormToStruct(form map[string][]string, target interface{}, tag string) (err error) {
 	if form == nil {
 		return fmt.Errorf("invalid form value: %#v", form)
 	}
@@ -216,7 +216,7 @@ func FormToStruct(form map[string][]string, target interface{}) (err error) {
 		if !fieldValue.CanSet() {
 			continue
 		}
-		fieldKey := fieldType.Tag.Get("form")
+		fieldKey := fieldType.Tag.Get(tag)
 		if fieldKey == "" {
 			continue
 		}

--- a/util_test.go
+++ b/util_test.go
@@ -618,45 +618,79 @@ func TestGearContentDisposition(t *testing.T) {
 }
 
 type formStruct struct {
-	String  string   `form:"string"`
-	Bool    bool     `form:"bool"`
-	Int     int      `form:"int"`
-	Int8    int8     `form:"int8"`
-	Int16   int16    `form:"int16"`
-	Int32   int32    `form:"int32"`
-	Int64   int64    `form:"int64"`
-	Uint    uint     `form:"uint"`
-	Uint8   uint8    `form:"uint8"`
-	Uint16  uint16   `form:"uint16"`
-	Uint32  uint32   `form:"uint32"`
-	Uint64  uint64   `form:"uint64"`
-	Float32 float32  `form:"float32"`
-	Float64 float64  `form:"float64"`
-	Slice1  []string `form:"slice1"`
-	Slice2  []int    `form:"slice2"`
-	Slice3  []int    `form:"slice3"`
-	Hide    string   `json:"hide"`
+	String   string    `form:"string"`
+	Bool     bool      `form:"bool"`
+	Int      int       `form:"int"`
+	Int8     int8      `form:"int8"`
+	Int16    int16     `form:"int16"`
+	Int32    int32     `form:"int32"`
+	Int64    int64     `form:"int64"`
+	Uint     uint      `form:"uint"`
+	Uint8    uint8     `form:"uint8"`
+	Uint16   uint16    `form:"uint16"`
+	Uint32   uint32    `form:"uint32"`
+	Uint64   uint64    `form:"uint64"`
+	Float32  float32   `form:"float32"`
+	Float64  float64   `form:"float64"`
+	Slice1   []string  `form:"pslice1"`
+	Slice2   []int     `form:"pslice2"`
+	Slice3   []int     `form:"slice3"`
+	Pstring  *string   `form:"pstring"`
+	Pbool    *bool     `form:"pbool"`
+	Pint     *int      `form:"pint"`
+	Pint8    *int8     `form:"pint8"`
+	Pint16   *int16    `form:"pint16"`
+	Pint32   *int32    `form:"pint32"`
+	Pint64   *int64    `form:"pint64"`
+	Puint    *uint     `form:"puint"`
+	Puint8   *uint8    `form:"puint8"`
+	Puint16  *uint16   `form:"puint16"`
+	Puint32  *uint32   `form:"puint32"`
+	Puint64  *uint64   `form:"puint64"`
+	Pfloat32 *float32  `form:"pfloat32"`
+	Pfloat64 *float64  `form:"pfloat64"`
+	Pslice1  []*string `form:"pslice1"`
+	Pslice2  []*int    `form:"pslice2"`
+	Pslice3  []*int    `form:"pslice3"`
+	Hide     string    `json:"hide"`
 }
 
 func TestGearFormToStruct(t *testing.T) {
 	data := url.Values{
-		"string":  {"string"},
-		"bool":    {"true"},
-		"int":     {"-1"},
-		"int8":    {"-1"},
-		"int16":   {"-1"},
-		"int32":   {"-1"},
-		"int64":   {"-1"},
-		"uint":    {"1"},
-		"uint8":   {"1"},
-		"uint16":  {"1"},
-		"uint32":  {"1"},
-		"uint64":  {"1"},
-		"float32": {"1.1"},
-		"float64": {"1.1"},
-		"slice1":  {"slice1"},
-		"slice2":  {"1"},
-		"slice3":  {},
+		"string":   {"string"},
+		"bool":     {"true"},
+		"int":      {"-1"},
+		"int8":     {"-1"},
+		"int16":    {"-1"},
+		"int32":    {"-1"},
+		"int64":    {"-1"},
+		"uint":     {"1"},
+		"uint8":    {"1"},
+		"uint16":   {"1"},
+		"uint32":   {"1"},
+		"uint64":   {"1"},
+		"float32":  {"1.1"},
+		"float64":  {"1.1"},
+		"slice1":   {"slice1"},
+		"slice2":   {"1"},
+		"slice3":   {},
+		"pstring":  {"string"},
+		"pbool":    {"true"},
+		"pint":     {"-1"},
+		"pint8":    {"-1"},
+		"pint16":   {"-1"},
+		"pint32":   {"-1"},
+		"pint64":   {"-1"},
+		"puint":    {"1"},
+		"puint8":   {"1"},
+		"puint16":  {"1"},
+		"puint32":  {"1"},
+		"puint64":  {"1"},
+		"pfloat32": {"1.1"},
+		"pfloat64": {"1.1"},
+		"pslice1":  {"slice1"},
+		"pslice2":  {"1"},
+		"pslice3":  {},
 	}
 
 	t.Run("Should error", func(t *testing.T) {
@@ -706,5 +740,25 @@ func TestGearFormToStruct(t *testing.T) {
 		assert.Equal([]string{"slice1"}, s.Slice1)
 		assert.Equal([]int{1}, s.Slice2)
 		assert.Equal([]int{}, s.Slice3)
+		assert.Nil(FormToStruct(data, &s, "form"))
+		assert.Equal("string", *s.Pstring)
+		assert.Equal(true, *s.Pbool)
+		assert.Equal(int(-1), *s.Pint)
+		assert.Equal(int8(-1), *s.Pint8)
+		assert.Equal(int16(-1), *s.Pint16)
+		assert.Equal(int32(-1), *s.Pint32)
+		assert.Equal(int64(-1), *s.Pint64)
+		assert.Equal(uint(1), *s.Puint)
+		assert.Equal(uint8(1), *s.Puint8)
+		assert.Equal(uint16(1), *s.Puint16)
+		assert.Equal(uint32(1), *s.Puint32)
+		assert.Equal(uint64(1), *s.Puint64)
+		assert.Equal(float32(1.1), *s.Pfloat32)
+		assert.Equal(float64(1.1), *s.Pfloat64)
+		slice1 := "slice1"
+		assert.Equal([]*string{&slice1}, s.Pslice1)
+		sliceint1 := 1
+		assert.Equal([]*int{&sliceint1}, s.Pslice2)
+		assert.Equal([]*int{}, s.Pslice3)
 	})
 }

--- a/util_test.go
+++ b/util_test.go
@@ -662,33 +662,33 @@ func TestGearFormToStruct(t *testing.T) {
 	t.Run("Should error", func(t *testing.T) {
 		assert := assert.New(t)
 
-		assert.NotNil(FormToStruct(nil, nil))
-		assert.NotNil(FormToStruct(data, nil))
+		assert.NotNil(FormToStruct(nil, nil, "form"))
+		assert.NotNil(FormToStruct(data, nil, "form"))
 
 		var v1 formStruct
 		var v2 *formStruct
-		assert.NotNil(FormToStruct(data, v1))
-		assert.NotNil(FormToStruct(data, v2))
+		assert.NotNil(FormToStruct(data, v1, "form"))
+		assert.NotNil(FormToStruct(data, v2, "form"))
 
 		v1 = formStruct{}
-		assert.NotNil(FormToStruct(data, v1))
+		assert.NotNil(FormToStruct(data, v1, "form"))
 
 		v3 := struct {
 			String interface{} `form:"string"`
 		}{}
-		assert.NotNil(FormToStruct(data, &v3))
+		assert.NotNil(FormToStruct(data, &v3, "form"))
 
 		v4 := struct {
 			Slice []int `form:"slice"`
 		}{}
-		assert.NotNil(FormToStruct(url.Values{"slice": {"a"}}, &v4))
+		assert.NotNil(FormToStruct(url.Values{"slice": {"a"}}, &v4, "form"))
 	})
 
 	t.Run("Should work", func(t *testing.T) {
 		assert := assert.New(t)
 
 		s := formStruct{}
-		assert.Nil(FormToStruct(data, &s))
+		assert.Nil(FormToStruct(data, &s, "form"))
 		assert.Equal("string", s.String)
 		assert.Equal(true, s.Bool)
 		assert.Equal(int(-1), s.Int)


### PR DESCRIPTION
ParseQuery parses query with QueryParser, stores the result in the value
pointed to by BodyTemplate body, and validate it.

Define a BodyTemplate type in some API:
```go
 type jsonQueryTemplate struct {
 	ID   string `json:"id" query:"id"`
 	Pass string `json:"pass" query:"pass"`
 }

 func (b *jsonQueryTemplate) Validate() error {
 	if len(b.ID) < 3 || len(b.Pass) < 6 {
 		return ErrBadRequest.WithMsg("invalid id or pass")
 	}
 	return nil
 }
```
there still another two issues need to be fixed in this pr?
* 1, I think is improper to still use the tag `form` when parse query, maybe use another tag `query`?
* 2, for now, ParseBody not support pointer type like `*string, *int`, whether it's necessary to add support for pointer type? because ParseQuery also use func `FormToStruct` to parse query, so it has the same problems.
