### PR TITLE
add default http err logger for slb health check

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"os"
 	"time"
+
+	"github.com/DavadDi/gear/logging"
 )
 
 // Middleware defines a function to process as middleware.
@@ -138,7 +140,7 @@ func New() *App {
 	app.Set(SetServerName, "Gear/"+Version)
 	app.Set(SetBodyParser, DefaultBodyParser(2<<20)) // 2MB
 	app.Set(SetURLParser, DefaultURLParser{})
-	app.Set(SetLogger, log.New(os.Stderr, "", log.LstdFlags))
+	app.Set(SetLogger, log.New(logging.DefaultSrvErr(), "", log.LstdFlags))
 	return app
 }
 

--- a/app.go
+++ b/app.go
@@ -11,8 +11,6 @@ import (
 	"net/url"
 	"os"
 	"time"
-
-	"github.com/DavadDi/gear/logging"
 )
 
 // Middleware defines a function to process as middleware.
@@ -140,7 +138,7 @@ func New() *App {
 	app.Set(SetServerName, "Gear/"+Version)
 	app.Set(SetBodyParser, DefaultBodyParser(2<<20)) // 2MB
 	app.Set(SetURLParser, DefaultURLParser{})
-	app.Set(SetLogger, log.New(logging.DefaultSrvErr(), "", log.LstdFlags))
+	app.Set(SetLogger, log.New(os.Stderr, "", log.LstdFlags))
 	return app
 }
 

--- a/logging/http_srv_err.go
+++ b/logging/http_srv_err.go
@@ -1,0 +1,58 @@
+package logging
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+// Https, avoid some handshake mismatch condition such as Aliyun SLB healthcheck (tcp or http)
+//
+// / 2017/06/09 07:18:04 http: TLS handshake error from 10.10.5.1:45001: tls: first record does not look like a TLS handshake
+// 2017/06/14 02:39:29 http: TLS handshake error from 10.0.1.2:54975: read tcp 10.10.5.22:8081->10.0.1.2:54975: read: connection reset by peer
+//
+//
+// Usage:
+// 	srvLogger := &logger.HttpSrvErrMgr{}
+//  srvLogger.AddIgnoreErr("http: TLS handshake error")
+//  srvLogger.AddIgnoreErr("EOF")
+//  app.Set(gear.SetLogger, log.New(srvLogger, "", log.LstdFlags))
+
+var httpErr = &HttpSrvErrMgr{
+	ignoreErrs:    [][]byte{[]byte("http: TLS handshake error"), []byte("EOF")},
+	defaultWriter: os.Stderr,
+}
+
+func DefaultSrvErr() *HttpSrvErrMgr {
+	return httpErr
+}
+
+type HttpSrvErrMgr struct {
+	ignoreErrs    [][]byte
+	defaultWriter io.Writer
+}
+
+// for test
+func (s *HttpSrvErrMgr) SetDefault(out io.Writer) {
+	s.defaultWriter = out
+}
+
+func (s *HttpSrvErrMgr) AddIgnoreErr(err string) {
+	s.ignoreErrs = append(s.ignoreErrs, []byte(err))
+}
+
+func (s *HttpSrvErrMgr) Write(p []byte) (n int, err error) {
+	skipFlag := false
+	for _, ignore := range s.ignoreErrs {
+		if bytes.Contains(p, ignore) {
+			skipFlag = true
+			break
+		}
+	}
+
+	if skipFlag {
+		return len(p), nil
+	}
+
+	return s.defaultWriter.Write(p)
+}

--- a/logging/http_srv_err_test.go
+++ b/logging/http_srv_err_test.go
@@ -1,0 +1,44 @@
+package logging
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIgnoreError(t *testing.T) {
+	assert := assert.New(t)
+	_ = assert
+
+	testMsgs := []struct {
+		Msg    string
+		Expect string
+	}{
+		{"http: TLS handshake error from 10.10.5.1:45001: tls: first record does not look like a TLS handshake", ""},
+		{"http: TLS handshake error from 10.0.1.2:54975: read tcp 10.10.5.22:8081->10.0.1.2:54975: read: connection reset by peer", ""},
+		{"error from 10.0.1.2:54975: read EOF", ""},
+		{"Hello World", "Hello World"},
+	}
+
+	for _, msg := range testMsgs {
+		r, w, _ := os.Pipe()
+		DefaultSrvErr().SetDefault(w)
+		log := log.New(DefaultSrvErr(), "", log.LstdFlags)
+		log.Print(msg.Msg)
+
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		if msg.Expect == "" {
+			assert.Equal(buf.Bytes(), []byte(msg.Expect))
+		} else {
+			assert.Contains(string(buf.Bytes()), msg.Expect)
+		}
+
+	}
+}


### PR DESCRIPTION
```go
func main() {
  	app := gear.New() // Create app
  	app.Use(func(ctx *gear.Context) error {
  		return ctx.HTML(200, "<h1>Hello, Gear!</h1>")
  	})
        // add http(s) error default mgr.
        app.Set(gear.SetLogger, log.New(logging.DefaultSrvErr(), "", log.LstdFlags))

  	app.Error(app.Listen(":3000"))
 }
```