### PR TITLE
add default http err logger for slb health check

### DIFF
--- a/app.go
+++ b/app.go
@@ -138,7 +138,13 @@ func New() *App {
 	app.Set(SetServerName, "Gear/"+Version)
 	app.Set(SetBodyParser, DefaultBodyParser(2<<20)) // 2MB
 	app.Set(SetURLParser, DefaultURLParser{})
-	app.Set(SetLogger, log.New(os.Stderr, "", log.LstdFlags))
+
+	if env == "development" {
+		app.Set(SetLogger, log.New(os.Stderr, "", log.LstdFlags))
+	} else {
+		app.Set(SetLogger, log.New(DefaultFilterWriter(), "", log.LstdFlags))
+	}
+
 	return app
 }
 

--- a/logger_filter_writer.go
+++ b/logger_filter_writer.go
@@ -1,0 +1,64 @@
+package gear
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+// Https, avoid some handshake mismatch condition such as Aliyun SLB healthcheck (tcp or http)
+//
+// / 2017/06/09 07:18:04 http: TLS handshake error from 10.10.5.1:45001: tls: first record does not look like a TLS handshake
+// 2017/06/14 02:39:29 http: TLS handshake error from 10.0.1.2:54975: read tcp 10.10.5.22:8081->10.0.1.2:54975: read: connection reset by peer
+//
+//
+// Usage:
+// func main() {
+//	app := gear.New() // Create app
+//	app.Use(func(ctx *gear.Context) error {
+//		return ctx.HTML(200, "<h1>Hello, Gear!</h1>")
+//	})
+//	// add http(s) error default mgr.
+//	app.Set(gear.SetLogger, log.New(logging.DefaultFilterWriter(), "", log.LstdFlags))
+//
+//	app.Error(app.Listen(":3000"))
+//}
+
+var loggerFilterWriter = &LoggerFilterWriter{
+	ignoreErrs:    [][]byte{[]byte("http: TLS handshake error"), []byte("EOF")},
+	defaultWriter: os.Stderr,
+}
+
+func DefaultFilterWriter() *LoggerFilterWriter {
+	return loggerFilterWriter
+}
+
+type LoggerFilterWriter struct {
+	ignoreErrs    [][]byte
+	defaultWriter io.Writer
+}
+
+// for test
+func (s *LoggerFilterWriter) SetDefault(out io.Writer) {
+	s.defaultWriter = out
+}
+
+func (s *LoggerFilterWriter) Add(err string) {
+	s.ignoreErrs = append(s.ignoreErrs, []byte(err))
+}
+
+func (s *LoggerFilterWriter) Write(p []byte) (n int, err error) {
+	skipFlag := false
+	for _, ignore := range s.ignoreErrs {
+		if bytes.Contains(p, ignore) {
+			skipFlag = true
+			break
+		}
+	}
+
+	if skipFlag {
+		return len(p), nil
+	}
+
+	return s.defaultWriter.Write(p)
+}

--- a/logger_filter_writer_test.go
+++ b/logger_filter_writer_test.go
@@ -1,0 +1,44 @@
+package gear
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIgnoreError(t *testing.T) {
+	assert := assert.New(t)
+	_ = assert
+
+	testMsgs := []struct {
+		Msg    string
+		Expect string
+	}{
+		{"http: TLS handshake error from 10.10.5.1:45001: tls: first record does not look like a TLS handshake", ""},
+		{"http: TLS handshake error from 10.0.1.2:54975: read tcp 10.10.5.22:8081->10.0.1.2:54975: read: connection reset by peer", ""},
+		{"error from 10.0.1.2:54975: read EOF", ""},
+		{"Hello World", "Hello World"},
+	}
+
+	for _, msg := range testMsgs {
+		r, w, _ := os.Pipe()
+		DefaultFilterWriter().SetDefault(w)
+		log := log.New(DefaultFilterWriter(), "", log.LstdFlags)
+		log.Print(msg.Msg)
+
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		if msg.Expect == "" {
+			assert.Equal(buf.Bytes(), []byte(msg.Expect))
+		} else {
+			assert.Contains(string(buf.Bytes()), msg.Expect)
+		}
+
+	}
+}


### PR DESCRIPTION
```go
func New() *App {
	app := new(App)
	app.Server = new(http.Server)
	app.mds = make(middlewares, 0)
	app.settings = make(map[interface{}]interface{})

	env := os.Getenv("APP_ENV")
	if env == "" {
		env = "development"
	}
	app.Set(SetEnv, env)
	app.Set(SetServerName, "Gear/"+Version)
	app.Set(SetBodyParser, DefaultBodyParser(2<<20)) // 2MB
	app.Set(SetURLParser, DefaultURLParser{})

	if env == "development" {
		app.Set(SetLogger, log.New(os.Stderr, "", log.LstdFlags))
	} else {
		app.Set(SetLogger, log.New(DefaultFilterWriter(), "", log.LstdFlags))
	}

	return app
}
```
Auto Convert into DefaultFilterWriter() when "env != development"