### PR TITLE
add method info to not implemented error message

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -458,7 +458,7 @@ ErrNotFound                      = Err.WithCode(http.StatusNotFound)
 
 ```go
 if r.otherwise == nil {
-  return ErrNotImplemented.WithMsgf(`"%s" is not implemented`, ctx.Path)
+  return ErrNotImplemented.WithMsgf(`"%s %s" is not implemented`, ctx.Method, ctx.Path)
 }
 ```
 

--- a/router.go
+++ b/router.go
@@ -299,7 +299,7 @@ func (r *Router) Serve(ctx *Context) error {
 		}
 
 		if r.otherwise == nil {
-			return ErrNotImplemented.WithMsgf(`"%s" is not implemented`, ctx.Path)
+			return ErrNotImplemented.WithMsgf(`"%s %s" is not implemented`, method, ctx.Path)
 		}
 		handler = r.otherwise
 	} else {

--- a/router_test.go
+++ b/router_test.go
@@ -241,7 +241,7 @@ func TestGearRouter(t *testing.T) {
 		assert.Equal(501, res.StatusCode)
 		assert.Equal("nosniff", res.Header.Get(HeaderXContentTypeOptions))
 		assert.Equal("application/json; charset=utf-8", res.Header.Get(HeaderContentType))
-		assert.Equal(`{"error":"NotImplemented","message":"\"/\" is not implemented"}`, PickRes(res.Text()).(string))
+		assert.Equal(`{"error":"NotImplemented","message":"\"GET /\" is not implemented"}`, PickRes(res.Text()).(string))
 		res.Body.Close()
 	})
 
@@ -606,7 +606,7 @@ func TestGearRouter(t *testing.T) {
 		assert.NotNil(err)
 		assert.Equal(501, err.(*Error).Code)
 		assert.Equal("NotImplemented", err.(*Error).Err)
-		assert.Equal(`"/abc//efg" is not implemented`, err.(*Error).Msg)
+		assert.Equal(`"GET /abc//efg" is not implemented`, err.(*Error).Msg)
 	})
 
 	t.Run("router with TrailingSlashRedirect = true (defalut)", func(t *testing.T) {


### PR DESCRIPTION
有时候 get / post 的 path 会相同, 加上 method 信息方便查找问题.