### PR TITLE
query parse: ignore query tag options

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -894,7 +894,7 @@ type PaginationEmbedTemplate struct {
 }
 
 type jsonQueryTemplate struct {
-	ID   string `json:"id" query:"id"`
+	ID   string `json:"id" query:"id,omitempty"`
 	Pass string `json:"pass" query:"pass"`
 	PaginationEmbedTemplate
 }

--- a/util.go
+++ b/util.go
@@ -305,6 +305,11 @@ func valuesToStruct(values map[string][]string, rv reflect.Value, tag string) (e
 			continue
 		}
 
+		// ignore tag options
+		if idx := strings.Index(fk, ","); idx > 0 {
+			fk = fk[:idx]
+		}
+
 		if vals, ok := values[fk]; ok {
 			if value.Kind() == reflect.Slice {
 				err = setRefSlice(value, vals)


### PR DESCRIPTION
```
// to be fixed
struct {
  A string `query:"a,omitempty"` // can not parse
}
```